### PR TITLE
Bump hardcoded BA(JP) bootstrap endpoint from r49 to r50

### DIFF
--- a/py/getModelsJapan.py
+++ b/py/getModelsJapan.py
@@ -13,7 +13,7 @@ option = {
     "skipExistingAssets": True
 }
 
-ba_api = "https://yostar-serverinfo.bluearchiveyostar.com/r49_mkbvd6abx0woazxgpyjr.json"
+ba_api = "https://yostar-serverinfo.bluearchiveyostar.com/r50_d561ioydiypbrigv2h6a.json"
 
 ba_api2 = "https://prod-noticeindex.bluearchiveyostar.com/prod/index.json"
 


### PR DESCRIPTION
闲来无事，对 iPadOS 客户端 (版本 `1.25.178527`) 抓包；结果中有 `https://prod-clientpatch.bluearchiveyostar.com/r50_1_25_d561ioydiypbrigv2h6a/TableBundles/Excel.zip` 。

展示 `https://yostar-serverinfo.bluearchiveyostar.com/r50_d561ioydiypbrigv2h6a.json`:

```json
{
  "ConnectionGroups": [
    {
      "Name": "JP-Prod-Audit",
      "ManagementDataUrl": "https://prod-noticeindex.bluearchiveyostar.com/prod/index.json",
      "IsProductionAddressables": true,
      "ApiUrl": "https://prod-game.bluearchiveyostar.com:5000/api/",
      "GatewayUrl": "https://prod-gateway.bluearchiveyostar.com:5100/api/",
      "KibanaLogUrl": "https://prod-logcollector.bluearchiveyostar.com:5300",
      "ProhibitedWordBlackListUri": "https://prod-notice.bluearchiveyostar.com/prod/ProhibitedWord/blacklist.csv",
      "ProhibitedWordWhiteListUri": "https://prod-notice.bluearchiveyostar.com/prod/ProhibitedWord/whitelist.csv",
      "CustomerServiceUrl": "https://bluearchive.jp/contact-1-hint",
      "OverrideConnectionGroups": [
        {
          "Name": "1.0",
          "AddressablesCatalogUrlRoot": "https://prod-clientpatch.bluearchiveyostar.com/m28_1_0_1_mashiro3"
        },
        {
          "Name": "1.25",
          "AddressablesCatalogUrlRoot": "https://prod-clientpatch.bluearchiveyostar.com/r50_1_25_h7f7m6p61xiaa0sgb1f7"
        }
      ],
      "BundleVersion": "vizsifOeuE"
    }
  ]
}
```